### PR TITLE
[CRAB-102] throwOnError추가 및 footer 정보 수정

### DIFF
--- a/src/app/academy/(workspace)/[id]/dashboard/components/(principal)/ChallengeEditForm/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/(principal)/ChallengeEditForm/index.tsx
@@ -56,7 +56,7 @@ function ChallengeEditForm({ points, title, totalDays, content, description, cha
   const queryClient = useQueryClient();
   const params = useParams();
   const { mutate } = useEditChallenge();
-  const { data: studentData, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteAcademyMemberDetailList(10, Number(params.id));
+  const { data: studentData, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteAcademyMemberDetailList(10, Number(params.id));
 
   const [selectedStudentIdList, setSelectedStudentIdList] = useState<number[]>([]);
   const watchCategory = watch('challengeParticipationMethod');
@@ -72,10 +72,6 @@ function ChallengeEditForm({ points, title, totalDays, content, description, cha
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return <div>에러가 발생했습니다. 다시 시도해주세요.</div>;
-  }
 
   const onSubmit = (data: FormValues) => {
     console.log(data);

--- a/src/app/academy/(workspace)/[id]/dashboard/components/(student)/ChallengeFeed/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/(student)/ChallengeFeed/index.tsx
@@ -16,7 +16,7 @@ interface IFeedProps {
 }
 
 function ChallengeFeed({ academyId }: IFeedProps) {
-  const { data: contents, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteFeedChallengeContents(academyId);
+  const { data: contents, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteFeedChallengeContents(academyId);
   const isEmpty = contents?.pages.every((page) => page.result.challengeLogList.length === 0);
 
   console.log(contents);
@@ -33,14 +33,6 @@ function ChallengeFeed({ academyId }: IFeedProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/dashboard/components/(student)/MyChallenge/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/(student)/MyChallenge/index.tsx
@@ -17,7 +17,7 @@ interface IMyChallengeProps {
 }
 
 function MyChallenge({ academyId, studentChallengeId }: IMyChallengeProps) {
-  const { data: contents, isError, isFetching, hasNextPage, fetchNextPage } = useInfiniteMyChallengeContents(academyId, studentChallengeId);
+  const { data: contents, isFetching, hasNextPage, fetchNextPage } = useInfiniteMyChallengeContents(academyId, studentChallengeId);
   const isEmpty = contents?.pages.every((page) => page.result.challengeLogList.length === 0);
 
   const { ref, inView } = useInView({
@@ -32,14 +32,6 @@ function MyChallenge({ academyId, studentChallengeId }: IMyChallengeProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/dashboard/components/AllChallengeContents/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/AllChallengeContents/index.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import AnimateCard from '@/app/academy/(workspace)/[id]/dashboard/components/AnimateCard';
 import PlusChallengeCard from '@/app/academy/(workspace)/[id]/dashboard/components/PlusChallengeCard';
 import { getChallengeCategory } from '@/features/academy/(workspace)/utils/challengeState';
-import Flex from '@/shared/components/Flex';
 import Typography from '@/shared/components/Typography';
 import { PUBLIC_CATEGORY_NAME } from '@/shared/constants/tab-menu';
 import useGetInfiniteTeacherChallengeList from '@/shared/hooks/challenge/useGetInfiniteTeacherChallengeList';
@@ -22,7 +21,7 @@ interface IAllChallengeContentsProps {
 function AllChallengeContents({ academyId, category, search }: IAllChallengeContentsProps) {
   const router = useRouter();
   const selectedCategory = PUBLIC_CATEGORY_NAME[category] ?? undefined;
-  const { data: challenge, fetchNextPage, hasNextPage, isFetching, isError } = useGetInfiniteTeacherChallengeList(academyId, selectedCategory, search);
+  const { data: challenge, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteTeacherChallengeList(academyId, selectedCategory, search);
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -36,14 +35,6 @@ function AllChallengeContents({ academyId, category, search }: IAllChallengeCont
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">

--- a/src/app/academy/(workspace)/[id]/dashboard/components/StudentCardList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/StudentCardList/index.tsx
@@ -16,7 +16,7 @@ interface IStudentCardListProps {
 }
 
 function StudentCardList({ academyId, releasedChallengeId }: IStudentCardListProps) {
-  const { data: students, fetchNextPage, hasNextPage, isFetching, isError } = useGetInfiniteStudentChallengeProgressList(academyId, releasedChallengeId);
+  const { data: students, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteStudentChallengeProgressList(academyId, releasedChallengeId);
   const isEmpty = students?.pages.every((page) => page.result.challengeParticipantList.length === 0);
 
   const { ref, inView } = useInView({
@@ -31,14 +31,6 @@ function StudentCardList({ academyId, releasedChallengeId }: IStudentCardListPro
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러 발생 !</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/dashboard/components/StudentChallengeContents/index.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/components/StudentChallengeContents/index.tsx
@@ -7,7 +7,6 @@ import StudentChallengeContent from '../StudentChallengeContent';
 
 import FallbackMessage from '@/shared/components/FallbackMessage';
 import Flex from '@/shared/components/Flex';
-import Typography from '@/shared/components/Typography';
 import useGetInfiniteStudentChallengeContents from '@/shared/hooks/challenge/useGetInfiniteStudentChallengeContents';
 
 interface IStudentChallengeContents {
@@ -17,13 +16,7 @@ interface IStudentChallengeContents {
 }
 
 function StudentChallengeContents({ academyId, releasedChallengeId, studentChallengeId }: IStudentChallengeContents) {
-  const {
-    data: contents,
-    fetchNextPage,
-    hasNextPage,
-    isFetching,
-    isError,
-  } = useGetInfiniteStudentChallengeContents(academyId, releasedChallengeId, studentChallengeId);
+  const { data: contents, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteStudentChallengeContents(academyId, releasedChallengeId, studentChallengeId);
   const isEmpty = contents?.pages.every((page) => page.result.challengeLogList.length === 0);
 
   const { ref, inView } = useInView({
@@ -38,14 +31,6 @@ function StudentChallengeContents({ academyId, releasedChallengeId, studentChall
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/dashboard/create/components/Third.tsx
+++ b/src/app/academy/(workspace)/[id]/dashboard/create/components/Third.tsx
@@ -32,7 +32,7 @@ function Third({ onBack, onNext, academyId }: IThirdProps) {
   } = useForm<FieldValues>({
     resolver: zodResolver(challengeSchema),
   });
-  const { data: studentData, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteAcademyMemberDetailList(10, academyId);
+  const { data: studentData, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteAcademyMemberDetailList(10, academyId);
 
   const [selectedStudentIdList, setSelectedStudentIdList] = useState<number[]>([]);
   const watchCategory = watch('challengeParticipationMethod');
@@ -48,10 +48,6 @@ function Third({ onBack, onNext, academyId }: IThirdProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return <div>에러가 발생했습니다. 다시 시도해주세요.</div>;
-  }
 
   const onSubmit = (data: FieldValues) => {
     if (data.challengeParticipationMethod === CHALLENGE_PARTICIPATION_METHODS.SELF_PARTICIPATING) {

--- a/src/app/academy/(workspace)/[id]/feed/components/CommentList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/feed/components/CommentList/index.tsx
@@ -5,7 +5,6 @@ import { useInView } from 'react-intersection-observer';
 
 import Comment from '@/app/academy/(workspace)/[id]/feed/components/Comment';
 import Flex from '@/shared/components/Flex';
-import Typography from '@/shared/components/Typography';
 import useGetInfiniteComments from '@/shared/hooks/comments/useGetInfiniteComments';
 
 interface ICommentBoxProps {
@@ -22,7 +21,6 @@ function CommentList({ academyId, releasedChallengeId, studentChallengeLogId }: 
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    isError,
   } = useGetInfiniteComments(academyId, releasedChallengeId, studentChallengeLogId);
   const { ref, inView } = useInView({
     threshold: 0,
@@ -37,13 +35,6 @@ function CommentList({ academyId, releasedChallengeId, studentChallengeLogId }: 
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
 
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
   return (
     <Flex column="start" className="gap-3">
       {commentList?.pages.map((page) =>

--- a/src/app/academy/(workspace)/[id]/market/components/ChallengeCardList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/market/components/ChallengeCardList/index.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import AnimateCard from '@/app/academy/(workspace)/[id]/dashboard/components/AnimateCard';
 import { getChallengeCategory } from '@/features/academy/(workspace)/utils/challengeState';
 import FallbackMessage from '@/shared/components/FallbackMessage';
-import Flex from '@/shared/components/Flex';
 import Typography from '@/shared/components/Typography';
 import type { CHALLENGE_TYPE } from '@/shared/enums/challenge';
 import useGetInfiniteMarketChallenge from '@/shared/hooks/market/useGetInfiniteMarketChallenges';
@@ -19,7 +18,7 @@ interface IChallengeCardListProps {
 
 function ChallengeCardList({ academyId, challengeType }: IChallengeCardListProps) {
   const router = useRouter();
-  const { data: challenges, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteMarketChallenge(academyId, challengeType);
+  const { data: challenges, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteMarketChallenge(academyId, challengeType);
   const isEmpty = challenges?.pages.every((page) => page.result.challengeList.length === 0);
 
   const { ref, inView } = useInView({
@@ -34,14 +33,6 @@ function ChallengeCardList({ academyId, challengeType }: IChallengeCardListProps
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/market/components/Release/First.tsx
+++ b/src/app/academy/(workspace)/[id]/market/components/Release/First.tsx
@@ -26,7 +26,7 @@ interface IFirstStep {
 }
 
 function FirstStep({ academyId, onNext }: IFirstStep) {
-  const { data: studentData, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteAcademyMemberDetailList(10, academyId);
+  const { data: studentData, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteAcademyMemberDetailList(10, academyId);
   const [selectedStudentIdList, setSelectedStudentIdList] = useState<number[]>([]);
   const { ref, inView } = useInView({
     threshold: 0,
@@ -73,14 +73,6 @@ function FirstStep({ academyId, onNext }: IFirstStep) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <form onSubmit={handleSubmit(handleRelease)} className="flex w-11/12 flex-col justify-center gap-10">

--- a/src/app/academy/(workspace)/[id]/public-challenge/components/PublicCardList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/public-challenge/components/PublicCardList/index.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import AnimateCard from '@/app/academy/(workspace)/[id]/dashboard/components/AnimateCard';
 import { getChallengeCategory } from '@/features/academy/(workspace)/utils/challengeState';
 import FallbackMessage from '@/shared/components/FallbackMessage';
-import Flex from '@/shared/components/Flex';
 import Typography from '@/shared/components/Typography';
 import { PUBLIC_CATEGORY_NAME } from '@/shared/constants/tab-menu';
 import useGetInfinitePublicChallenge from '@/shared/hooks/public/useGetInfinitePublicChallenge';
@@ -20,7 +19,7 @@ interface IPublicCardListProps {
 function PublicCardList({ academyId, category }: IPublicCardListProps) {
   const router = useRouter();
   const selectedCategory = PUBLIC_CATEGORY_NAME[category] ?? undefined;
-  const { data: challenge, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfinitePublicChallenge(academyId, selectedCategory);
+  const { data: challenge, isFetching, hasNextPage, fetchNextPage } = useGetInfinitePublicChallenge(academyId, selectedCategory);
   const isEmpty = challenge?.pages.every((page) => page.result.academyPublicChallengeList.length === 0);
 
   const { ref, inView } = useInView({
@@ -35,14 +34,6 @@ function PublicCardList({ academyId, category }: IPublicCardListProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   if (isEmpty) {
     return (

--- a/src/app/academy/(workspace)/[id]/setting/components/InstructorList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/setting/components/InstructorList/index.tsx
@@ -4,9 +4,7 @@ import React, { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useRouter } from 'next/navigation';
 
-import Flex from '@/shared/components/Flex';
 import ProfileCard from '@/shared/components/ProfileCard';
-import Typography from '@/shared/components/Typography';
 import useGetInfiniteAcademyInstructorList from '@/shared/hooks/academy/useGetInfiniteAcademyInstructorList';
 
 interface IInstructorListProps {
@@ -15,7 +13,7 @@ interface IInstructorListProps {
 
 function InstructorList({ academyId }: IInstructorListProps) {
   const router = useRouter();
-  const { data: instructorData, hasNextPage, isFetching, fetchNextPage, isError } = useGetInfiniteAcademyInstructorList(6, academyId);
+  const { data: instructorData, hasNextPage, isFetching, fetchNextPage } = useGetInfiniteAcademyInstructorList(6, academyId);
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -29,14 +27,6 @@ function InstructorList({ academyId }: IInstructorListProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <div className="grid w-full grid-cols-1 gap-5 pl-0 md:pl-10 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">

--- a/src/app/academy/(workspace)/[id]/setting/components/StudentList/index.tsx
+++ b/src/app/academy/(workspace)/[id]/setting/components/StudentList/index.tsx
@@ -4,9 +4,7 @@ import React, { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useRouter } from 'next/navigation';
 
-import Flex from '@/shared/components/Flex';
 import ProfileCard from '@/shared/components/ProfileCard';
-import Typography from '@/shared/components/Typography';
 import useGetInfiniteAcademyMemberDetailList from '@/shared/hooks/academy/useGetInfiniteAcademyMemberDetailList';
 
 interface IStudentListProps {
@@ -15,7 +13,7 @@ interface IStudentListProps {
 
 function StudentList({ academyId }: IStudentListProps) {
   const router = useRouter();
-  const { data: studentList, isFetching, hasNextPage, fetchNextPage, isError } = useGetInfiniteAcademyMemberDetailList(9, academyId);
+  const { data: studentList, isFetching, hasNextPage, fetchNextPage } = useGetInfiniteAcademyMemberDetailList(9, academyId);
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -29,14 +27,6 @@ function StudentList({ academyId }: IStudentListProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <div className="grid w-full grid-cols-1 gap-5 pl-0 md:pl-10 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">

--- a/src/app/my/components/academy-list/index.tsx
+++ b/src/app/my/components/academy-list/index.tsx
@@ -8,7 +8,6 @@ import useInvitationModal from '../../hooks/use-invitation-modal';
 
 import AnimateCard from '@/app/academy/(workspace)/[id]/dashboard/components/AnimateCard';
 import PlusChallengeCard from '@/app/academy/(workspace)/[id]/dashboard/components/PlusChallengeCard';
-import Flex from '@/shared/components/Flex';
 import Typography from '@/shared/components/Typography';
 import useGetInfiniteAcademyList from '@/shared/hooks/academy/useGetInfiniteAcademyList';
 import { getRoleName } from '@/shared/utils/academyRole';
@@ -16,7 +15,7 @@ import { getRoleName } from '@/shared/utils/academyRole';
 function AcademyList() {
   const router = useRouter();
   const invitationModal = useInvitationModal();
-  const { data: academies, fetchNextPage, hasNextPage, isFetching, isError } = useGetInfiniteAcademyList();
+  const { data: academies, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteAcademyList();
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -30,14 +29,6 @@ function AcademyList() {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <div className="grid h-full grid-cols-1 gap-6 md:grid-cols-3 lg:grid-cols-4">

--- a/src/features/academy/(workspace)/components/my-challenge-list/index.tsx
+++ b/src/features/academy/(workspace)/components/my-challenge-list/index.tsx
@@ -6,7 +6,6 @@ import { useInView } from 'react-intersection-observer';
 import ChallengeCard from '@/features/academy/(workspace)/components/challenge-card';
 import MyChallengeCard from '@/features/academy/(workspace)/components/my-challenge-card';
 import Flex from '@/shared/components/Flex';
-import Typography from '@/shared/components/Typography';
 import useGetInfiniteStudentChallengeList from '@/shared/hooks/challenge/useGetInfiniteStudentChallengeList';
 
 interface IMyChallengeListProps {
@@ -14,7 +13,7 @@ interface IMyChallengeListProps {
 }
 
 function MyChallengeList({ academyId }: IMyChallengeListProps) {
-  const { data: challenge, fetchNextPage, hasNextPage, isFetching, isError } = useGetInfiniteStudentChallengeList(academyId);
+  const { data: challenge, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteStudentChallengeList(academyId);
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -28,14 +27,6 @@ function MyChallengeList({ academyId }: IMyChallengeListProps) {
       }
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
-
-  if (isError) {
-    return (
-      <Flex>
-        <Typography size="h5">에러가 발생했습니다.</Typography>
-      </Flex>
-    );
-  }
 
   return (
     <Flex column="center" className="size-full items-center gap-4 overflow-y-auto">

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -13,7 +13,10 @@ function Footer() {
             대표자 : 김현지 | 소재지: 서울특별시 금천구 범안로15길 22-5 (독산동) 금천청년꿈터 503호
           </Typography>
           <Typography size="h5" as="p" className="text-xs text-white">
-            주식회사 크래빗 | 사업자 등록번호: 010-8791-2483
+            주식회사 크래빗 | 사업자 등록번호: 747-86-03279
+          </Typography>
+          <Typography size="h5" as="p" className="text-xs text-white">
+            유선번호 : 010-8791-2483
           </Typography>
         </Flex>
         {/* <Typography size="h5" as="p" className="text-xs text-white">

--- a/src/shared/hooks/academy/useGetInfiniteAcademyInstructorList.ts
+++ b/src/shared/hooks/academy/useGetInfiniteAcademyInstructorList.ts
@@ -23,6 +23,7 @@ function useGetInfiniteAcademyInstructorList(
     queryKey: [queryKeys.ACADEMY_INSTRUCTOR_LIST],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/academy/useGetInfiniteAcademyList.ts
+++ b/src/shared/hooks/academy/useGetInfiniteAcademyList.ts
@@ -13,6 +13,7 @@ function useGetInfiniteAcademyList(
     queryKey: [queryKeys.ACADEMY_LIST],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/academy/useGetInfiniteAcademyMemberDetailList.ts
+++ b/src/shared/hooks/academy/useGetInfiniteAcademyMemberDetailList.ts
@@ -23,6 +23,7 @@ function useGetInfiniteAcademyMemberDetailList(
     queryKey: [queryKeys.ACADEMY_STUDENT_DETAIL_LIST],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/academy/useGetInfiniteAcademyStudentList.ts
+++ b/src/shared/hooks/academy/useGetInfiniteAcademyStudentList.ts
@@ -23,6 +23,7 @@ function useGetInfiniteAcademyMemberDetailList(
     queryKey: [queryKeys.ACADEMY_STUDENT_LIST, { academyId }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useGetInfiniteFeedChallengeContents.ts
+++ b/src/shared/hooks/challenge/useGetInfiniteFeedChallengeContents.ts
@@ -13,6 +13,7 @@ function useGetInfiniteFeedChallengeContents(
     queryKey: [queryKeys.CHALLENGE_FEED_LIST, { academyId }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useGetInfiniteStudentChallengeContents.ts
+++ b/src/shared/hooks/challenge/useGetInfiniteStudentChallengeContents.ts
@@ -23,6 +23,7 @@ function useGetInfiniteStudentChallengeContents(
     queryKey: [queryKeys.CHALLENGE_STUDENT_CONTENTS, academyId, releasedChallengeId, studentChallengeId],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useGetInfiniteStudentChallengeList.ts
+++ b/src/shared/hooks/challenge/useGetInfiniteStudentChallengeList.ts
@@ -27,6 +27,7 @@ function useGetInfiniteStudentChallengeList(
     queryKey: [queryKeys.STUDENT_CHALLENGE_LIST, { academyId }, categoryKey, searchKey],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useGetInfiniteStudentChallengeProgressList.ts
+++ b/src/shared/hooks/challenge/useGetInfiniteStudentChallengeProgressList.ts
@@ -22,6 +22,7 @@ function useGetInfiniteStudentChallengeProgressList(
     queryKey: [queryKeys.CHALLENGE_STUDENT_PROGRESS_LIST, { academyId }, { releasedChallengeId }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useGetInfiniteTeacherChallengeList.ts
+++ b/src/shared/hooks/challenge/useGetInfiniteTeacherChallengeList.ts
@@ -20,6 +20,7 @@ function useGetInfiniteTeacherChallengeList(
     queryKey: [queryKeys.CHALLENGE_LIST, { academyId }, categoryKey, searchKey],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/challenge/useInfiniteMyChallengeContents.ts
+++ b/src/shared/hooks/challenge/useInfiniteMyChallengeContents.ts
@@ -21,6 +21,7 @@ function useInfiniteMyChallengeContents(
     queryKey: [queryKeys.MY_CHALLENGE_CONTENTS, { academyId }, { studentChallengeId }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/comments/useGetInfiniteComments.ts
+++ b/src/shared/hooks/comments/useGetInfiniteComments.ts
@@ -16,6 +16,7 @@ function useGetInfiniteComments(
     queryKey: [queryKeys.COMMENT_LIST, { academyId }, { releasedChallengeId }, { studentChallengeLogId }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/market/useGetInfiniteMarketChallenges.ts
+++ b/src/shared/hooks/market/useGetInfiniteMarketChallenges.ts
@@ -23,6 +23,7 @@ function useGetInfiniteMarketChallenge(
     queryKey: [queryKeys.CHALLENGE_MARKET, { academyId }, { challengeType }],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }

--- a/src/shared/hooks/public/useGetInfinitePublicChallenge.ts
+++ b/src/shared/hooks/public/useGetInfinitePublicChallenge.ts
@@ -27,6 +27,7 @@ function useGetInfinitePublicChallenge(
     queryKey: [queryKeys.PUBLIC_CHALLENGE_LIST, { academyId }, categoryKey],
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.result.hasNext ? lastPage.result.nextCursor : undefined),
+    throwOnError: true,
     ...queryOptions,
   });
 }


### PR DESCRIPTION
## 🎈 어떤 이슈와 관련된 PR인가요?
> 이슈 번호를 기입해주세요!

## 📝 해당 PR에서 작업한 내용을 설명해주세요.
> 이번 PR은 어떤 작업을 담고 있는지 간략히 설명해주세요!
- [x] tanstack-query에 throwOnError 옵션을 추가하여 공통 error.tsx에 걸릴 수 있도록 수정하였습니다. (기존 isError ~ 삭제)
- [x] footer 사업자 등록 번호 변경 및 유선 번호 추가 


### 작업 내용과 관련된 스크린샷을 첨부해주세요. (선택 사항)

## 💬 리뷰어 전달 사항
> 리뷰어가 특별히 알아야 하는 사항을 설명해주세요.
> ex. ~파일에서 ~기능을 구현했는데 이렇게 하는게 과연 맞는 방식일까요?
<img width="200" alt="스크린샷 2024-12-07 12 59 55" src="https://github.com/user-attachments/assets/45056ced-6cc3-4a9c-a404-4f169121ae10">
-> 이제 이 문구가 뜨지 않고 공통적으로 토끼로고가 나오는 에러로 뜹니다 !